### PR TITLE
Add option saveAspectRatio

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Keep element within constrained box
 - `snapToGrid`: Snaps the shape to a virtual grid while resizing (default `1`)
 - `snapToAngle`: Snaps to an angle when rotating (default `0.1`)
 - `constraint`: Keep element within constrained box (see usage above); The box snaps to the grid defined by `snapToGrid`.
+- `saveAspectRatio`: Save aspect ratio of the element while resizing with left-top, left-bottom, right-top, right-bottom points.
 
 
 # Events

--- a/src/svg.resize.js
+++ b/src/svg.resize.js
@@ -145,6 +145,8 @@
                             return;
                         }
 
+                        snap = this.checkAspectRatio(snap);
+
                         this.el.move(this.parameters.box.x + snap[0], this.parameters.box.y + snap[1]).size(this.parameters.box.width - snap[0], this.parameters.box.height - snap[1]);
                     }
                 };
@@ -161,6 +163,8 @@
                             this.el.attr("font-size", this.parameters.fontSize + snap[0]);
                             return;
                         }
+
+                        snap = this.checkAspectRatio(snap);
 
                         this.el.move(this.parameters.box.x, this.parameters.box.y + snap[1]).size(this.parameters.box.width + snap[0], this.parameters.box.height - snap[1]);
                     }
@@ -179,6 +183,8 @@
                             return;
                         }
 
+                        snap = this.checkAspectRatio(snap);
+
                         this.el.move(this.parameters.box.x, this.parameters.box.y).size(this.parameters.box.width + snap[0], this.parameters.box.height + snap[1]);
                     }
                 };
@@ -195,6 +201,8 @@
                             this.el.attr("font-size", this.parameters.fontSize - snap[0]);
                             return;
                         }
+
+                        snap = this.checkAspectRatio(snap);
 
                         this.el.move(this.parameters.box.x + snap[0], this.parameters.box.y).size(this.parameters.box.width - snap[0], this.parameters.box.height + snap[1]);
                     }
@@ -421,6 +429,29 @@
         return [diffX, diffY];
     };
 
+    ResizeHandler.prototype.checkAspectRatio = function (snap) {
+        if (!this.options.saveAspectRatio) {
+            return snap;
+        }
+
+        var updatedSnap = snap.slice();
+        var aspectRatio = this.parameters.box.width / this.parameters.box.height;
+        var newW = this.parameters.box.width + snap[0];
+        var newH = this.parameters.box.height - snap[1];
+        var newAspectRatio = newW / newH;
+
+        if (newAspectRatio < aspectRatio) {
+            // Height is too big. Adapt it
+            updatedSnap[1] = newW / aspectRatio - this.parameters.box.height;
+        } else if (newAspectRatio > aspectRatio) {
+            // Width is too big. Adapt it
+            updatedSnap[0] = this.parameters.box.width - newH * aspectRatio;
+        }
+
+        return updatedSnap;
+
+    };
+
     SVG.extend(SVG.Element, {
         // Resize element with mouse
         resize: function (options) {
@@ -434,9 +465,10 @@
     });
 
     SVG.Element.prototype.resize.defaults = {
-        snapToAngle: 0.1,    // Specifies the speed the rotation is happening when moving the mouse
-        snapToGrid: 1,       // Snaps to a grid of `snapToGrid` Pixels
-        constraint: {}       // keep element within constrained box
+        snapToAngle: 0.1,       // Specifies the speed the rotation is happening when moving the mouse
+        snapToGrid: 1,          // Snaps to a grid of `snapToGrid` Pixels
+        constraint: {},         // keep element within constrained box
+        saveAspectRatio: false  // Save aspect ratio when resizing using lt, rt, rb or lb points
     };
 
 }).call(this);


### PR DESCRIPTION
This PR should close or partially close #10 
If `saveAspectRatio` is true, then element saves its aspect ratio while resizing with lt, rt, rb or lb points. Points t, b, l, r are not affected.